### PR TITLE
test: increase test coverage

### DIFF
--- a/adapters/nativery/nativerytest/supplemental/bad_bid_response.json
+++ b/adapters/nativery/nativerytest/supplemental/bad_bid_response.json
@@ -1,0 +1,74 @@
+{
+  "mockBidRequest": {
+    "id": "bad-bid-ext",
+    "imp": [
+      {
+        "id": "1",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "widgetId": "123" } }
+      }
+    ],
+    "site": { "page": "http://example.com", "ref": "http://example.com" },
+    "device": { "ua": "ua", "h": 100, "w": 200 }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "method": "POST",
+        "uri": "http://example.com/hb",
+        "body": {
+          "id": "bad-bid-ext",
+          "imp": [
+            {
+              "id": "1",
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": { "widgetId": "123" } }
+            }
+          ],
+          "site": {
+            "page": "http://example.com",
+            "ref": "http://example.com"
+          },
+          "device": { "ua": "ua", "h": 100, "w": 200 },
+          "ext": {
+            "nativery": {
+              "isAmp": false,
+              "widgetId": "123"
+            }
+          }
+        },
+        "impIDs": ["1"]
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "r",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "b1",
+                  "impid": "1",
+                  "price": 1.2,
+                  "adm": "<div></div>",
+                  "ext": 123
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "expectedRequestCount": 1,
+  "expectedMakeRequestsErrors": [],
+  "expectedMakeBidsErrors": [
+    { "value": "expect { or n, but found", "comparison": "startswith" }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "EUR",
+      "bids": []
+    }
+  ]
+}

--- a/adapters/nativery/nativerytest/supplemental/invalid_widget_id.json
+++ b/adapters/nativery/nativerytest/supplemental/invalid_widget_id.json
@@ -1,0 +1,29 @@
+{
+  "mockBidRequest": {
+    "id": "err-nativeryext-widgetid-number",
+    "imp": [
+      {
+        "id": "1",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": { "widgetId": "1" } }
+      }
+    ],
+    "site": { "page": "http://example.com", "ref": "http://example.com" },
+    "device": { "ua": "ua", "h": 100, "w": 200 },
+    "ext": {
+      "nativery": {
+        "isAmp": false,
+        "widgetId": 123
+      }
+    }
+  },
+  "expectedRequestCount": 0,
+  "expectedMakeRequestsErrors": [
+    {
+      "comparison": "regex",
+      "value": ".*cannot unmarshal nativery.*WidgetId.*"
+    }
+  ],
+  "expectedMakeBidsErrors": [],
+  "expectedBidResponses": []
+}

--- a/adapters/nativery/nativerytest/supplemental/missing_widget_id.json
+++ b/adapters/nativery/nativerytest/supplemental/missing_widget_id.json
@@ -1,0 +1,57 @@
+{
+  "mockBidRequest": {
+    "id": "missing-widgetid-400",
+    "imp": [
+      {
+        "id": "1",
+        "banner": { "format": [{ "w": 300, "h": 250 }] },
+        "ext": { "bidder": {} }
+      }
+    ],
+    "site": { "page": "http://example.com", "ref": "http://example.com" },
+    "device": { "ua": "ua", "h": 100, "w": 200 }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "method": "POST",
+        "uri": "http://example.com/hb",
+        "body": {
+          "id": "missing-widgetid-400",
+          "imp": [
+            {
+              "id": "1",
+              "banner": { "format": [{ "w": 300, "h": 250 }] },
+              "ext": { "bidder": {} }
+            }
+          ],
+          "site": {
+            "page": "http://example.com",
+            "ref": "http://example.com"
+          },
+          "device": { "ua": "ua", "h": 100, "w": 200 },
+          "ext": {
+            "nativery": {
+              "isAmp": false,
+              "widgetId": ""
+            }
+          }
+        },
+        "impIDs": ["1"]
+      },
+      "mockResponse": {
+        "status": 400,
+        "body": ""
+      }
+    }
+  ],
+  "expectedRequestCount": 1,
+  "expectedMakeRequestsErrors": [],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 400",
+      "comparison": "startswith"
+    }
+  ],
+  "expectedBidResponses": []
+}

--- a/adapters/nativery/nativerytest/supplemental/status_204_nativery_error.json
+++ b/adapters/nativery/nativerytest/supplemental/status_204_nativery_error.json
@@ -1,0 +1,88 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "widgetId": "1"
+          }
+        }
+      }
+    ],
+    "site": {
+      "page": "http://example.com",
+      "ref": "http://example.com"
+    },
+    "device": {
+      "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36",
+      "h": 500,
+      "w": 1000
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://example.com/hb",
+        "body": {
+          "id": "test-request-id",
+          "ext": {
+            "nativery": {
+              "isAmp": false,
+              "widgetId": "1"
+            }
+          },
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "widgetId": "1"
+                }
+              }
+            }
+          ],
+          "site": {
+            "page": "http://example.com",
+            "ref": "http://example.com"
+          },
+          "device": {
+            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36",
+            "h": 500,
+            "w": 1000
+          }
+        },
+        "impIDs": ["test-imp-id"]
+      },
+      "mockResponse": {
+        "status": 204,
+        "body": {},
+        "headers": { "X-Nativery-Error": ["some error"] },
+        "error": ["No Content"]
+      }
+    }
+  ],
+
+  "expectedBidResponses": [],
+
+  "expectedMakeBidsErrors": [
+    { "value": "Nativery Error: some error.", "comparison": "startswith" }
+  ]
+}


### PR DESCRIPTION
# About this pull request

We’ve added supplemental JSON tests for the error in getNativeryExt (e.g. widgetId of the wrong type) and also extended coverage with additional cases in MakeBids (204 with/without X-Nativery-Error, malformed bid.ext, bad response JSON, etc.).

For the other two error branches (getRequestExt and the first unmarshal in buildNativeryExt), these are not reachable with the supplemental JSON harness: the loader rejects any request.ext or imp.ext that is not a JSON object before it even reaches the adapter, so the errors cannot be triggered that way. Those paths are only hit if Prebid-server were fed invalidly shaped JSON at runtime, which the framework prevents.

So coverage is now above 90%, and all error paths that can be reached via the supplemental tests are exercised. The remaining uncovered lines are structurally unreachable via the harness, not due to missing tests.